### PR TITLE
[FEAT] Added group_by method

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,25 @@ flipped_subtract.(2, 1) # => -1
 ```
 * * *
 
+### <a id="_group_by"></a>`R_.group_by(collection, iteratee)`
+
+Creates an object composed of keys generated from the results of running each element of collection thru iteratee. The order of grouped values is determined by the order they occur in collection. The corresponding value of each key is an array of elements responsible for generating the key. The iteratee is invoked with one argument: (value).
+
+#### Arguments
+`collection` *(Array|Hash)*: The collection to iterate over.
+`[iteratee=_.identity]` (Proc): The iteratee to transform keys.
+
+#### Returns
+*(Object)*: Returns the composed aggregate object.
+
+#### Example
+```ruby
+iteratee = ->(value) { value.floor }
+R_.group_by([6.1, 4.2, 6.3], iteratee);
+# => { '4': [4.2], '6': [6.1, 6.3] }
+```
+* * *
+
 ### <a id="_negate"></a>`R_.negate(func)`
 
 Creates a proc that negates the result of the passed proc.

--- a/lib/rudash.rb
+++ b/lib/rudash.rb
@@ -45,6 +45,7 @@ require_relative './rudash/remove.rb'
 require_relative './rudash/union.rb'
 require_relative './rudash/reject.rb'
 require_relative './rudash/range.rb'
+require_relative './rudash/group_by.rb'
 
 # This is the exposed Gem class that contains all Rudash methods.
 # New methods can use already implemented methods in the library by refering to "self"
@@ -97,4 +98,5 @@ class R_
     extend Rudash::Union
     extend Rudash::Reject
     extend Rudash::Range
+    extend Rudash::GroupBy
 end

--- a/lib/rudash/group_by.rb
+++ b/lib/rudash/group_by.rb
@@ -1,0 +1,20 @@
+module Rudash
+    module GroupBy
+        def group_by(collection, iteratee = self.method(:identity))
+
+            reducer = ->(acc, current) {
+                key = Rudash::DynamicArgsCount.call(iteratee, current)
+
+                if acc[key]
+                    acc[key] << current
+                else
+                    acc[key] = [current]
+                end
+
+                acc
+            }
+
+            self.reduce(collection, reducer, {})
+        end
+    end
+end

--- a/rudash.gemspec
+++ b/rudash.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
     s.name = %q{rudash}
-    s.version = '2.10.0'
+    s.version = '2.11.0'
     s.date = %q{2019-07-07}
     s.authors = ['Islam Attrash']
     s.email = 'isattrash@gmail.com'

--- a/test/group_by.rb
+++ b/test/group_by.rb
@@ -1,0 +1,19 @@
+require_relative '../lib/rudash'
+require 'test/unit'
+
+class GroupByTest < Test::Unit::TestCase
+    def test_without_iterator_fn
+        collection = [6.1, 4.2, 6.3]
+        expected = {6.1=> [6.1], 4.2=> [4.2], 6.3=> [6.3]}
+
+        assert_equal R_.group_by(collection), expected
+    end
+
+    def with_iterator_fn
+        collection = [6.1, 4.2, 6.3]
+        iterator = ->(value) { value.floor }
+        expected = { 4 => [4.2], 6 => [6.1, 6.3] }
+
+        assert_equal R_.group_by(collection, iterator), expected
+    end
+end


### PR DESCRIPTION
### <a id="_group_by"></a>`R_.group_by(collection, iteratee)`

 Creates an object composed of keys generated from the results of running each element of collection thru iteratee. The order of grouped values is determined by the order they occur in collection. The corresponding value of each key is an array of elements responsible for generating the key. The iteratee is invoked with one argument: (value).

 #### Arguments
`collection` *(Array|Hash)*: The collection to iterate over.
`[iteratee=_.identity]` (Proc): The iteratee to transform keys.

 #### Returns
*(Object)*: Returns the composed aggregate object.

 #### Example
```ruby
iteratee = ->(value) { value.floor }
R_.group_by([6.1, 4.2, 6.3], iteratee);
# => { '4': [4.2], '6': [6.1, 6.3] }
```
* * *