### PR TITLE
[FEAT] Add drop_right method

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,26 @@ R_.without(arr1, 2, 3) # => [1]
 ```
 * * *
 
+### <a id="_drop_right"></a>`R_.drop_right(array, [n=1])`
+
+Creates a slice of `array` with `n` elements dropped from the end.
+
+#### Arguments
+`array` *(Array)*: The array to inspect.
+`[n=1]` *(number)*: The number of elements to drop.
+
+#### Returns
+*(Array)*: Returns the slice of `array`.
+
+#### Example
+```ruby
+array = [1, 2, 3]
+
+R_.drop_right(array) # => [1, 2]
+R_.drop_right(array, 2) # => [1]
+```
+* * *
+
 ## `“Collection” Methods`
 
 ### <a id="_each"></a>`R_.each(collection, iteratee_fn = R_.identity)`

--- a/lib/rudash.rb
+++ b/lib/rudash.rb
@@ -47,6 +47,7 @@ require_relative './rudash/reject.rb'
 require_relative './rudash/range.rb'
 require_relative './rudash/group_by.rb'
 require_relative './rudash/take.rb'
+require_relative './rudash/drop_right.rb'
 
 # This is the exposed Gem class that contains all Rudash methods.
 # New methods can use already implemented methods in the library by refering to "self"
@@ -101,4 +102,5 @@ class R_
     extend Rudash::Range
     extend Rudash::GroupBy
     extend Rudash::Take
+    extend Rudash::DropRight
 end

--- a/lib/rudash/drop_right.rb
+++ b/lib/rudash/drop_right.rb
@@ -1,0 +1,12 @@
+module Rudash
+    module DropRight
+        def drop_right(array, *rest_args)
+            return [] if !self.is_array?(array)
+
+            n = self.head(rest_args) || 1
+            return array if n <= 0
+
+            self.take(array, self.size(array) - n)
+        end
+    end
+end

--- a/rudash.gemspec
+++ b/rudash.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
     s.name = %q{rudash}
-    s.version = '2.12.1'
+    s.version = '2.13.0'
     s.date = %q{2019-07-07}
     s.authors = ['Islam Attrash']
     s.email = 'isattrash@gmail.com'

--- a/test/drop_right.rb
+++ b/test/drop_right.rb
@@ -1,0 +1,34 @@
+require_relative '../lib/rudash'
+require 'test/unit'
+
+class DropRightTest < Test::Unit::TestCase
+    def test_array_no_args
+        result = R_.drop_right([1,2,3])
+        assert_equal result, [1,2]
+    end
+
+    def test_array_negative_count
+        result = R_.drop_right([1,2,3], -5)
+        assert_equal result, [1,2,3]
+    end
+
+    def test_array_postitive_count
+        result = R_.drop_right([1,2,3], 2)
+        assert_equal result, [1]
+    end
+
+    def test_empty_array
+        result = R_.drop_right([])
+        assert_equal result, []
+    end
+
+    def test_hash
+        result = R_.drop_right({a: 1})
+        assert_equal result, []
+    end
+
+    def test_nil
+        result = R_.drop_right(nil)
+        assert_equal result, []
+    end
+end


### PR DESCRIPTION
Resolves https://github.com/Attrash-Islam/rudash/issues/85

Adds the [`dropRight`](https://lodash.com/docs/4.17.15#dropRight) function.

Test cases were copied from `test/take.rb`, and adjusted as necessary:

```
$ ruby ./test/drop_right.rb
Loaded suite ./test/drop_right
Started
......
Finished in 0.000871 seconds.
---------------------------------------------------------------------------------------------------------
6 tests, 6 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------
6888.63 tests/s, 6888.63 assertions/s
```