### PR TITLE
Rename Proc -> Lambda

### DIFF
--- a/lib/rudash/curry.rb
+++ b/lib/rudash/curry.rb
@@ -1,7 +1,7 @@
 module Rudash
   module Curry
-    def curry(a_proc)
-      a_proc.is_a?(Proc) ? a_proc.curry : (raise 'Expected a Proc')
+    def curry(a_lambda)
+      a_lambda.is_a?(Proc) ? a_lambda.curry : (raise 'Expected a Lambda')
     end
   end
 end

--- a/lib/rudash/flip.rb
+++ b/lib/rudash/flip.rb
@@ -1,12 +1,12 @@
 module Rudash
   module Flip
-    def flip(a_proc)
-      raise 'Expected a Proc/Method' unless Rudash::Utils.function?(a_proc)
+    def flip(a_lambda)
+      raise 'Expected a lambda/Method' unless Rudash::Utils.function?(a_lambda)
 
       ->(*args) {
         reveresed_args = args.reverse
 
-        a_proc.call(*reveresed_args)
+        a_lambda.call(*reveresed_args)
       }
     end
   end

--- a/lib/rudash/negate.rb
+++ b/lib/rudash/negate.rb
@@ -1,9 +1,9 @@
 module Rudash
   module Negate
-    def negate(a_proc)
-      raise 'Expected a Proc/Method' unless Rudash::Utils.function?(a_proc)
+    def negate(a_lambda)
+      raise 'Expected a lambda/Method' unless Rudash::Utils.function?(a_lambda)
 
-      ->(*args) { !a_proc.call(*args) }
+      ->(*args) { !a_lambda.call(*args) }
     end
   end
 end

--- a/lib/utils/dynamic_args_count.rb
+++ b/lib/utils/dynamic_args_count.rb
@@ -3,7 +3,7 @@
 # once you configured a function with a specific set of arguments then you must call it with that
 # set or else you will get an exception.
 # That is so useful for predicate functions that developer define out of the library scope.
-# We send all the arguments to the developer defined Proc and if it's failed
+# We send all the arguments to the developer defined lambda and if it's failed
 # because of ArgumentError we call it recursively with less argument until success.
 
 module Rudash

--- a/lib/utils/subset_deep_match.rb
+++ b/lib/utils/subset_deep_match.rb
@@ -34,7 +34,7 @@ module Rudash
             })
 
             # That was done for performance manners since
-            # R_.each don't stop when returning false from the proc
+            # R_.each don't stop when returning false from the lambda
             # so we force it to stop by throwing an exception that we catch later
             # It's the same hack for JavaScript forEach function.
             raise if match == false

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Rudash
-  VERSION = '3.0.6'.freeze
+  VERSION = '3.0.7'.freeze
 end

--- a/test/curry.rb
+++ b/test/curry.rb
@@ -8,7 +8,7 @@ class CurryTest < Test::Unit::TestCase
     assert_equal inc_by_one[3], 4
   end
 
-  def test_expected_proc_exception
+  def test_expected_lambda_exception
     assert_raise do
       R_.curry({})
     end

--- a/test/filter.rb
+++ b/test/filter.rb
@@ -51,7 +51,7 @@ class FilterTest < Test::Unit::TestCase
     assert_equal result, [1, 0, { a: 1 }]
   end
 
-  def test_filter_with_wrong_proc
+  def test_filter_with_wrong_predicate
     result = R_.filter([1, 0, nil, { a: 1 }], 5)
     assert_equal result, []
   end

--- a/test/map.rb
+++ b/test/map.rb
@@ -8,7 +8,7 @@ class MapTest < Test::Unit::TestCase
     assert_equal result, [2, 4, 6]
   end
 
-  def test_not_proc
+  def test_not_predicate
     result = R_.map([1, 2, 3], 6)
     assert_equal result, [nil, nil, nil]
   end

--- a/test/reduce.rb
+++ b/test/reduce.rb
@@ -10,7 +10,7 @@ class ReduceTest < Test::Unit::TestCase
     assert_equal R_.reduce([1, 2, 3, 4, 5], sumer), 15
   end
 
-  def test_reducer_not_proc
+  def test_reducer_not_lambda
     assert_equal R_.reduce([1, 2, 3, 4, 5], 6), nil
   end
 

--- a/test/reject.rb
+++ b/test/reject.rb
@@ -53,12 +53,12 @@ class RejectTest < Test::Unit::TestCase
     ]
   end
 
-  def test_array_default_reject_proc
+  def test_array_default_reject_lambda
     result = R_.reject([1, 0, nil, { a: 1 }])
     assert_equal result, [nil]
   end
 
-  def test_hash_default_reject_proc
+  def test_hash_default_reject_lambda
     result = R_.reject(a: 1, b: nil)
     assert_equal result, [nil]
   end

--- a/test/update.rb
+++ b/test/update.rb
@@ -8,7 +8,7 @@ class UpdateTest < Test::Unit::TestCase
     assert_equal hash, a: 1
   end
 
-  def test_updater_not_proc
+  def test_updater_not_lambda
     hash = { a: 1 }
     R_.update(hash, 'a', 65)
     assert_equal hash, a: 1


### PR DESCRIPTION
I'm doing this change for two reasons:

- Developers don't know what is Proc but most of the them heard of Lambda even from other languages.
- I literally used and embraced the Lambda over the Proc, both in the Implementation and in the Documentation.